### PR TITLE
Update org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml

### DIFF
--- a/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
+++ b/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
@@ -26,6 +26,10 @@
       <summary>Ctags Executable</summary>
       <description>Specifies the executable path for Exuberant Ctags.</description>
     </key>
+    <key type="s" name="ctags-append">
+      <default>''</default>
+      <summary>Ctags Append</summary>
+      <description>Specifies any command line modifiers to apply to Ctags when run by the parser.</description>
+    </key>
   </schema>
 </schemalist>
-


### PR DESCRIPTION
Scripting accommodations for a "ctags append" feature that allows appending the ctags command in the parser with options. I originally made this so I could easily configure ctags with options like "--langmap=javascript:.itz.js.node"

For this system, I have modified three key files:

configure_dialog.ui
plugin.py
org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
